### PR TITLE
Add readme and prebuilt APK for MLPerf Inference 0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MLPerf Mobile App #
 
-This repo hosts the MLPerf mobile app, an app-based implementationn of
+This project contains the MLPerf mobile app, an app-based implementationn of
 [MLPerf Inference](https://github.com/mlperf/inference) tasks.
 
 ## Overview ##
@@ -8,10 +8,11 @@ This repo hosts the MLPerf mobile app, an app-based implementationn of
 The MLPerf app offers a simple mobile UI for executing MLPerf inference tasks and comparing results. The user can select a task, a supported reference model (float or quantized), and initiate both latency and accuracy validation for that task. As single-stream represents the most common inference execution on mobile devices, that is the default mode of inference measurement, with the results showing the 90%-ile latency and the task-specific accuracy metric result (e.g., top-1 accuracy for image classification).
 
 Several important mobile-specific considerations are addressed in the app:
-* Limited disk space - Certain datasets are quite large (multiple gigabytes), which makes an exhaustive evaluation difficult. By default, the app does not include the full dataset for validation. The client can optionally push part or all of the task validation datasets, depending on their use-case.
-* Device variability - The number of CPU, GPU and DSP/NPU hardware permutations in the mobile ecosystem is quite large. To this end, the app affords the option to customize hardware execution, e.g., adjusting the number of threads for CPU inference, enabling GPU acceleration, or NN API acceleration (Android’s ML abstraction layer for accelerating inference).
 
-The initial version of the app builds off of a lightweight, C++ task evaluation pipeline originally built for [TensorFlow Lite](https://github.com/tensorflow/tensorflow). Most of the default MLPerf inference reference implementations are built in Python, which is generally incompatible with mobile deployment. This C++ evaluation pipeline has a minimal set of dependencies for pre-processing datasets and post-processing, is compatible with iOS and Android (as well as desktop platforms), and integrates with the standard MLPerf LoadGen library. While the initial version of the app uses TensorFlow Lite as the default inference engine, the plan is to support addition of alternative inference frameworks contributed by the broader MLPerf community.
+*   Limited disk space - Certain datasets are quite large (multiple gigabytes), which makes an exhaustive evaluation difficult. By default, the app does not include the full dataset for validation. The client can optionally push part or all of the task validation datasets, depending on their use-case.
+*   Device variability - The number of CPU, GPU and DSP/NPU hardware permutations in the mobile ecosystem is quite large. To this end, the app affords the option to customize hardware execution, e.g., adjusting the number of threads for CPU inference, enabling GPU acceleration, or NN API acceleration (Android’s ML abstraction layer for accelerating inference).
+
+The initial version of the app builds off of a lightweight, C++ task evaluation pipeline originally built for [TensorFlow Lite](https://www.tensorflow.org/lite/). Most of the default MLPerf inference reference implementations are built in Python, which is generally incompatible with mobile deployment. This C++ evaluation pipeline has a minimal set of dependencies for pre-processing datasets and post-processing, is compatible with iOS and Android (as well as desktop platforms), and integrates with the standard [MLPerf LoadGen library](https://github.com/mlperf/inference/tree/master/loadgen). While the initial version of the app uses TensorFlow Lite as the default inference engine, the plan is to support addition of alternative inference frameworks contributed by the broader MLPerf community.
 
 ## Getting Started ##
 
@@ -21,31 +22,25 @@ Note: The source code for the app will be available soon.
 
 ## FAQ ##
 
- * When will the source be available?
+
+#### When will the source be available?  ####
 
 Soon!
 
- * Will this be available in the app store(s)?
+#### Will this be available in the app store(s)? ####
 
 Yes, eventually, but not with the 0.5 release.
 
- * When will an iOS version be avilable?
+#### When will an iOS version be avilable? ####
 
 This is a priority for the community but requires some additional resourcing.
 
- * Will the app support all MLPerf Inference tasks?
+#### Will the app support all MLPerf Inference tasks? ####
 
 That is the eventual goal. To start, it supports only those tasks specifically targeting mobile and/or edge use-cases (e.g., Classification w/ MobileNet, Detection w/ SSD MobileNet).
 
- * Will the app support more than just TensorFlow Lite for inference?
+#### Will the app support more than just TensorFlow Lite for inference? ####
 
 Yes, that is the plan, though this is largely dependent on contributions from teams and organizations who desire this.
 
 Please search https://groups.google.com/forum/#!forum/mlperf-inference-submitters for additional help and related questions.
-
-
-
-
-
-
-

--- a/README.md
+++ b/README.md
@@ -1,1 +1,51 @@
-This file contains the MLPerf Mobile App, currently undergoing development. Community contributions are very welcome!
+# MLPerf Mobile App #
+
+This repo hosts the MLPerf mobile app, an app-based implementationn of
+[MLPerf Inference](https://github.com/mlperf/inference) tasks.
+
+## Overview ##
+
+The MLPerf app offers a simple mobile UI for executing MLPerf inference tasks and comparing results. The user can select a task, a supported reference model (float or quantized), and initiate both latency and accuracy validation for that task. As single-stream represents the most common inference execution on mobile devices, that is the default mode of inference measurement, with the results showing the 90%-ile latency and the task-specific accuracy metric result (e.g., top-1 accuracy for image classification).
+
+Several important mobile-specific considerations are addressed in the app:
+* Limited disk space - Certain datasets are quite large (multiple gigabytes), which makes an exhaustive evaluation difficult. By default, the app does not include the full dataset for validation. The client can optionally push part or all of the task validation datasets, depending on their use-case.
+* Device variability - The number of CPU, GPU and DSP/NPU hardware permutations in the mobile ecosystem is quite large. To this end, the app affords the option to customize hardware execution, e.g., adjusting the number of threads for CPU inference, enabling GPU acceleration, or NN API acceleration (Android’s ML abstraction layer for accelerating inference).
+
+The initial version of the app builds off of a lightweight, C++ task evaluation pipeline originally built for [TensorFlow Lite](https://github.com/tensorflow/tensorflow). Most of the default MLPerf inference reference implementations are built in Python, which is generally incompatible with mobile deployment. This C++ evaluation pipeline has a minimal set of dependencies for pre-processing datasets and post-processing, is compatible with iOS and Android (as well as desktop platforms), and integrates with the standard MLPerf LoadGen library. While the initial version of the app uses TensorFlow Lite as the default inference engine, the plan is to support addition of alternative inference frameworks contributed by the broader MLPerf community.
+
+## Getting Started ##
+
+Please see [these instructions](prebuilt/README.md) for using the prebuilt Android app.
+
+Note: The source code for the app will be available soon.
+
+## FAQ ##
+
+ * When will the source be available?
+
+Soon!
+
+ * Will this be available in the app store(s)?
+
+Yes, eventually, but not with the 0.5 release.
+
+ * When will an iOS version be avilable?
+
+This is a priority for the community but requires some additional resourcing.
+
+ * Will the app support all MLPerf Inference tasks?
+
+That is the eventual goal. To start, it supports only those tasks specifically targeting mobile and/or edge use-cases (e.g., Classification w/ MobileNet, Detection w/ SSD MobileNet).
+
+ * Will the app support more than just TensorFlow Lite for inference?
+
+Yes, that is the plan, though this is largely dependent on contributions from teams and organizations who desire this.
+
+Please search https://groups.google.com/forum/#!forum/mlperf-inference-submitters for additional help and related questions.
+
+
+
+
+
+
+

--- a/prebuilt/README.md
+++ b/prebuilt/README.md
@@ -1,0 +1,68 @@
+# Prebuilt MLPerf Mobile App #
+
+This directory contains prebuilt versions of the MLPerf (Android) app, for convenience.
+
+## Getting Started ##
+
+Until the app is available in the [Play Store](https://play.google.com/store?hl=en_US), it requires
+manual installation from a host machine. note that, due to restrictions in dataset redistribution,
+some amount of manual retrieval, processing and packaging is required to use certain task datasets
+for accuracy evaluation.
+
+### Requirements ###
+
+ * [Android SDK](https://developer.android.com/studio)
+ * Android 4.4+ w/ [USB debugging enabled](https://developer.android.com/studio/debug/dev-options)
+
+### App installation ###
+
+Install the app via `adb` as follows:
+
+```
+adb install ${ROOT_DIR}/prebuilt/MLPerf_0.5_beta.apk
+```
+
+### Dataset installation ###
+
+While a task dataset isn't required for measuring latency, it is required for measuring accuracy.
+
+This currently requires some manual work to prepare and distribute the relevant datasets. Note that
+the full datasets can be extremely large; a subset of the full dataset can be prepared to give a
+useful proxy for task-specific accuracy. When prepared, each task directory should be pushed to
+`/sdcard/mlperf_datasets/...`.
+
+#### Imagenet (Classifiaction) ####
+
+The app evaluations Image Classification via MobileNet V1
+(float & quantized), using any subset of images used in the
+[ILSVRC 2012 image classification task](http://www.image-net.org/challenges/LSVRC/2012/).
+
+Expected folder data layout:
+
+*   `imagenet/img` : `folder` \
+    Contains the set of images to evaluate over. This could be any subset of the ILSVRC
+    2012 evaluation dataset.
+
+*   `imagenet/val.txt` : `txt file` \
+    Validation file containing a list of `$IMAGE_NAME $IMAGE_LABEL_INDEX` pairs,
+    where `$IMAGE_NAME` is the filanme from the `img/` folder, and `$IMAGE_LABEL_INDEX` is the
+    expected label index from inference output.
+
+The classification model files are already in the app, for convenience. Once the data has been
+prepared, push the resulting `imagenet` folder to `/sdcard/mlperf_datasets/imagenet`.
+
+#### Coco (Detection) ####
+
+## App Execution ##
+
+After the app and dataset(s) have been installed, simply open `MLPerf Inference` from the Android launcher. The
+app UI allows selection of supported tasks, and execution of the supported models (float/quantized)
+for each task.
+
+
+The user can also configure runtime execution with the following options:
+ * Number of threads - for CPU execution
+ * Delegate (accelerator):
+    * None - Default (CPU) path
+    * GPU - Enables use of the GPU (via OpenGL/OpennCL)
+    * NNAPI - Enables use of [Android's NN API](https://developer.android.com/ndk/guides/neuralnetworks)

--- a/prebuilt/README.md
+++ b/prebuilt/README.md
@@ -5,64 +5,81 @@ This directory contains prebuilt versions of the MLPerf (Android) app, for conve
 ## Getting Started ##
 
 Until the app is available in the [Play Store](https://play.google.com/store?hl=en_US), it requires
-manual installation from a host machine. note that, due to restrictions in dataset redistribution,
-some amount of manual retrieval, processing and packaging is required to use certain task datasets
-for accuracy evaluation.
+manual installation from a host machine. Due to restrictions in dataset redistribution, some amount
+of manual retrieval, processing and packaging is required to use certain task datasets
+for accuracy evaluation. We're actively investigating how we can bundle the necessary datasets directly in the app.
 
 ### Requirements ###
 
- * [Android SDK](https://developer.android.com/studio)
- * Android 4.4+ w/ [USB debugging enabled](https://developer.android.com/studio/debug/dev-options)
+*   [Android SDK](https://developer.android.com/studio)
+*   Android 6.0+ (Marshmallow+) w/ [USB debugging enabled](https://developer.android.com/studio/debug/dev-options)
 
 ### App installation ###
 
 Install the app via `adb` as follows:
 
 ```
-adb install ${ROOT_DIR}/prebuilt/MLPerf_0.5_beta.apk
+  adb install ${ROOT_DIR}/prebuilt/MLPerf_0.5_alpha.apk
 ```
+
+The prebuilt APK contains libraries for 32 and 64-bit ARM devices, as well as
+for 32-bit x86 devices (primarily for testing).
+
+If you're primarily interested in testing inference latency, skip directly to
+the [App Execution](#app-execution) section. The app can run MLPerf latency
+measurements without the need for full dataset installation.
 
 ### Dataset installation ###
 
-While a task dataset isn't required for measuring latency, it is required for measuring accuracy.
+A tasks-specific dataset is required required for measuring accuracy.
 
 This currently requires some manual work to prepare and distribute the relevant datasets. Note that
 the full datasets can be extremely large; a subset of the full dataset can be prepared to give a
 useful proxy for task-specific accuracy. When prepared, each task directory should be pushed to
 `/sdcard/mlperf_datasets/...`.
 
-#### Imagenet (Classifiaction) ####
+#### Imagenet (Classification) ####
 
-The app evaluations Image Classification via MobileNet V1
+The app evaluates Image Classification via MobileNet V1
 (float & quantized), using any subset of images used in the
-[ILSVRC 2012 image classification task](http://www.image-net.org/challenges/LSVRC/2012/).
+[ILSVRC 2012 image classification task](http://www.image-net.org/download-images/).
 
-Expected folder data layout:
+To download the 2012 dataset, you will need to do the following:
+
+*   Open the [ImageNet downloads link](http://www.image-net.org/download-images), creating an ImageNet account if you have not done so already.
+*   Navigate to the 2012 downloads page under the **`Download links to ILSVRC image data`** section.
+*   Download the **`Validation images (all tasks)`** archive.
+*   Create a staging directory for the dataset, call it `${WORKING_DIR}/imagenet`.
+*   From the downloaded archive, extract the images into a `${WORKING_DIR}/imagenet/img` directory.
+
+The full set of validation images is quite large, over 6GB. This can take an
+extremely long time to process, so it is *highly* recommended that you use
+a smaller subset of images. We recommend leaving ~300 images in `${WORKING_DIR}/imagenet/img`.
+The resulting folder contents should appear like:
 
 *   `imagenet/img` : `folder` \
     Contains the set of images to evaluate over. This could be any subset of the ILSVRC
-    2012 evaluation dataset.
+    2012 evaluation dataset (strongly recommend using <300 for test/dev purposes).
 
-*   `imagenet/val.txt` : `txt file` \
-    Validation file containing a list of `$IMAGE_NAME $IMAGE_LABEL_INDEX` pairs,
-    where `$IMAGE_NAME` is the filanme from the `img/` folder, and `$IMAGE_LABEL_INDEX` is the
-    expected label index from inference output.
-
-The classification model files are already in the app, for convenience. Once the data has been
-prepared, push the resulting `imagenet` folder to `/sdcard/mlperf_datasets/imagenet`.
+The classification model and validation label files are already in the app, for convenience. Once
+the data has been prepared, push the resulting `imagenet` folder to `/sdcard/mlperf_datasets/imagenet`.
 
 #### Coco (Detection) ####
 
-## App Execution ##
+** Coming soon! **
 
-After the app and dataset(s) have been installed, simply open `MLPerf Inference` from the Android launcher. The
+## <a name="app-execution"></a> App Execution ##
+
+After the app has been installed, and the optional dataset(s), simply open **`MLPerf Inference`** from the Android launcher. The
 app UI allows selection of supported tasks, and execution of the supported models (float/quantized)
-for each task.
+for each task. If a dataset has been pushed for the task, the task-specific
+accuracy will be measured, otherwise it will only report latency results.
 
 
 The user can also configure runtime execution with the following options:
- * Number of threads - for CPU execution
- * Delegate (accelerator):
-    * None - Default (CPU) path
-    * GPU - Enables use of the GPU (via OpenGL/OpennCL)
-    * NNAPI - Enables use of [Android's NN API](https://developer.android.com/ndk/guides/neuralnetworks)
+
+*   TensorFlow Lite Accelerator:
+    *   None - Default (CPU) backend for TensorFlow Lite
+    *   GPU - Enables use of the GPU (via OpenGL/OpennCL)
+    *   NNAPI - Enables use of [Android's NN API](https://developer.android.com/ndk/guides/neuralnetworks)
+*   Number of threads - for CPU execution


### PR DESCRIPTION
This update includes a basic description of the MLPerf mobile app, as well as instructions on how to use the prebuilt Android APK to test inference latency and accuracy.

The source code will be available soon.