### PR TITLE
make it build

### DIFF
--- a/cpp/datasets/coco.cc
+++ b/cpp/datasets/coco.cc
@@ -49,6 +49,7 @@ inline TfLiteType DataType2TfType(DataType::Type type) {
     case DataType::Float16:
       return kTfLiteFloat16;
   }
+  return kTfLiteNoType;
 }
 }  // namespace
 

--- a/cpp/datasets/imagenet.cc
+++ b/cpp/datasets/imagenet.cc
@@ -44,6 +44,7 @@ inline TfLiteType DataType2TfType(DataType::Type type) {
     case DataType::Float16:
       return kTfLiteFloat16;
   }
+  return kTfLiteNoType;
 }
 
 // Default cropping fraction value.


### PR DESCRIPTION
On Ubuntu 18.04, I can't build the apk with
```
bazel build -c opt  --cxxopt='--std=c++14' \
  --fat_apk_cpu=x86,arm64-v8a,armeabi-v7a \
  //java/org/mlperf/inference:mlperf_app
```
because without this workaround I saw
```
cpp/datasets/coco.cc:42:11: warning: enumeration values 'Int32' and 'Int64' not handled in switch [-Wswitch]
  switch (type) {
          ^
cpp/datasets/coco.cc:52:1: error: control may reach end of non-void function [-Werror,-Wreturn-type]
}
^
1 warning and 1 error generated.
Target //java/org/mlperf/inference:mlperf_app failed to build
```