### PR TITLE
Deeplab ade20k loadgen

### DIFF
--- a/cpp/backends/tflite.cc
+++ b/cpp/backends/tflite.cc
@@ -136,6 +136,9 @@ std::vector<void*> TfliteBackend::GetPredictedOutputs() {
       case kTfLiteFloat16:
         outputs.push_back(output_tensor->data.f16);
         break;
+      case kTfLiteInt32:
+        outputs.push_back(output_tensor->data.i32);
+        break;
       case kTfLiteInt64:
         outputs.push_back(output_tensor->data.i64);
         break;

--- a/cpp/binary/BUILD
+++ b/cpp/binary/BUILD
@@ -35,6 +35,7 @@ cc_binary(
         "//cpp:mlperf_driver",
         "//cpp:utils",
         "//cpp/backends:tflite",
+        "//cpp/datasets:ade20k",
         "//cpp/datasets:coco",
         "//cpp/datasets:dummy_dataset",
         "//cpp/datasets:imagenet",

--- a/cpp/binary/main.cc
+++ b/cpp/binary/main.cc
@@ -20,6 +20,7 @@ limitations under the License.
 
 #include "absl/strings/match.h"
 #include "cpp/backends/tflite.h"
+#include "cpp/datasets/ade20k.h"
 #include "cpp/datasets/coco.h"
 #include "cpp/datasets/dummy_dataset.h"
 #include "cpp/datasets/imagenet.h"
@@ -53,6 +54,8 @@ DatasetConfig::DatasetType Str2DatasetType(absl::string_view name) {
     return DatasetConfig::IMAGENET;
   } else if (absl::EqualsIgnoreCase(name, "SQUAD")) {
     return DatasetConfig::SQUAD;
+  } else if (absl::EqualsIgnoreCase(name, "ADE20K")) {
+    return DatasetConfig::ADE20K;
   } else if (absl::EqualsIgnoreCase(name, "DUMMY")) {
     return DatasetConfig::NONE;
   } else {
@@ -224,6 +227,33 @@ int Main(int argc, char* argv[]) {
         dataset.reset(new Squad(backend->GetInputFormat(),
                                 backend->GetOutputFormat(), input_tfrecord,
                                 gt_tfrecord));
+      }
+      // Adds to flag_list for showing help.
+      flag_list.insert(flag_list.end(), dataset_flags.begin(),
+                       dataset_flags.end());
+    } break;
+    case DatasetConfig::ADE20K: {
+      LOG(INFO) << "Using ADE20K dataset";
+      std::string images_directory, ground_truth_directory;
+      int num_classes = 31;
+      int image_width = 512, image_height = 512;
+      std::vector<Flag> dataset_flags{
+          Flag::CreateFlag("images_directory", &images_directory,
+                           "Path to ground truth images.", Flag::kRequired),
+          Flag::CreateFlag("ground_truth_directory", &ground_truth_directory,
+                           "Path to the imagenet ground truth file.",
+                           Flag::kRequired),
+          Flag::CreateFlag("num_class", &num_classes, "number of classes"),
+          Flag::CreateFlag("image_width", &image_width,
+                           "The width of the processed image."),
+          Flag::CreateFlag("image_height", &image_height,
+                           "The height of the processed image.")};
+      if (Flags::Parse(&argc, const_cast<const char**>(argv), dataset_flags) &&
+          backend) {
+        dataset.reset(new ADE20K(backend->GetInputFormat(),
+                                 backend->GetOutputFormat(), images_directory,
+                                 ground_truth_directory, num_classes,
+                                 image_width, image_height));
       }
       // Adds to flag_list for showing help.
       flag_list.insert(flag_list.end(), dataset_flags.begin(),

--- a/cpp/datasets/BUILD
+++ b/cpp/datasets/BUILD
@@ -95,3 +95,17 @@ cc_library(
         ],
     }),
 )
+
+cc_library(
+    name = "ade20k",
+    srcs = ["ade20k.cc"],
+    hdrs = ["ade20k.h"],
+    deps = [
+        "//cpp:mlperf_driver",
+        "//cpp:utils",
+        "@org_tensorflow//tensorflow/lite/kernels:kernel_util",
+        "@org_tensorflow//tensorflow/lite/tools/evaluation:utils",
+        "@org_tensorflow//tensorflow/lite/tools/evaluation/proto:evaluation_stages_cc_proto",
+        "@org_tensorflow//tensorflow/lite/tools/evaluation/stages:image_preprocessing_stage",
+    ],
+)

--- a/cpp/datasets/README.md
+++ b/cpp/datasets/README.md
@@ -82,13 +82,15 @@ you need to replace `squad_eval_mini.tfrecord` by `squad_eval.tfrecord` in the
 ## ADE20K
 1. prepare 512x512 images and and ground truth file with something like the following
 ```python
+import os
 import tensorflow as tf
 import deeplab.input_preprocess
 from PIL import Image as Image
 
 tf.enable_eager_execution()
 
-ADE20K_PATH=${HOME}/tf-models/research/deeplab/datasets/ADE20K/ADEChallengeData2016/'
+home = os.getenv("HOME")
+ADE20K_PATH = home + '/tf-models/research/deeplab/datasets/ADE20K/ADEChallengeData2016/'
 
 for i in range(1, 2001):
     image_jpeg = ADE20K_PATH+f'images/validation/ADE_val_0000{i:04}.jpg'

--- a/cpp/datasets/README.md
+++ b/cpp/datasets/README.md
@@ -78,3 +78,48 @@ generated with above default parameters. By default, the app will use a
 of the dataset with 160 random questions. To evaluate using the full dataset,
 you need to replace `squad_eval_mini.tfrecord` by `squad_eval.tfrecord` in the
 `java/org/mlperf/inference/assets/tasks.pbtxt` file.
+
+## ADE20K
+1. prepare 512x512 images and and ground truth file with something like the following
+```python
+import tensorflow as tf
+import deeplab.input_preprocess
+from PIL import Image as Image
+
+tf.enable_eager_execution()
+
+ADE20K_PATH='/home/freedom/tf-models/research/deeplab/datasets/ADE20K/ADEChallengeData2016/'
+
+for i in range(1, 2001):
+    image_jpeg = ADE20K_PATH+f'images/validation/ADE_val_0000{i:04}.jpg'
+    label_png = ADE20K_PATH+f'annotations/validation/ADE_val_0000{i:04}.png'
+    # print(image_jpeg)
+    image_jpeg_data = tf.io.read_file(image_jpeg)
+    image_tensor = tf.io.decode_jpeg(image_jpeg_data)
+    label_png_data = tf.io.read_file(label_png)
+    label_tensor = tf.io.decode_jpeg(label_png_data)
+    o_image, p_image, p_label = deeplab.input_preprocess.preprocess_image_and_label(image_tensor, label_tensor, 512, 512, 512, 512, is_training=False)
+
+    target_image_jpeg = f'/tmp/ade20k_512/images/validation/ADE_val_0000{i:04}.jpg'
+    target_label_raw = f'/tmp/ade20k_512/annotations/raw/ADE_val_0000{i:04}.raw'
+
+    resized_image = Image.fromarray(tf.reshape(tf.cast(p_image, tf.uint8), [512, 512, 3]).numpy())
+    resized_image.save(target_image_jpeg)
+    tf.reshape(tf.cast(p_label, tf.uint8), [512, 512]).numpy().tofile(target_label_raw)
+```
+
+2. Build command line tool to test performance and accuracy on x86 host
+
+```
+build  --cxxopt='--std=c++14' --host_cxxopt='--std=c++14' --copt=-march=native //cpp/binary:main
+```
+3. test with the command line tool
+```
+./bazel-bin/cpp/binary/main tflite ade20k \
+  --mode=PerformanceOnly \
+  --output_dir=/tmp/test_output \
+  --model_file=/tmp/freeze_quant_ops16_32c_clean.tflite \
+  --images_directory=/tmp/ade20k_512/images/validation  \
+  --ground_truth_directory=/tmp/ade20k_512/annotations/raw  \
+  --num_threads=4
+```

--- a/cpp/datasets/README.md
+++ b/cpp/datasets/README.md
@@ -88,7 +88,7 @@ from PIL import Image as Image
 
 tf.enable_eager_execution()
 
-ADE20K_PATH='/home/freedom/tf-models/research/deeplab/datasets/ADE20K/ADEChallengeData2016/'
+ADE20K_PATH=${HOME}/tf-models/research/deeplab/datasets/ADE20K/ADEChallengeData2016/'
 
 for i in range(1, 2001):
     image_jpeg = ADE20K_PATH+f'images/validation/ADE_val_0000{i:04}.jpg'

--- a/cpp/datasets/ade20k.cc
+++ b/cpp/datasets/ade20k.cc
@@ -57,7 +57,7 @@ ADE20K::ADE20K(const DataFormat& input_format, const DataFormat& output_format,
       image_width_(image_width),
       image_height_(image_height) {
   if (input_format_.size() != 1 || output_format_.size() != 1) {
-    LOG(FATAL) << "Imagenet only supports 1 input and 1 output";
+    LOG(FATAL) << "ADE20K model only supports 1 input and 1 output";
     return;
   }
   // Finds all images under image_dir.
@@ -70,7 +70,6 @@ ADE20K::ADE20K(const DataFormat& input_format, const DataFormat& output_format,
   }
   samples_ =
       std::vector<std::vector<std::vector<uint8_t>*>>(image_list_.size());
-  LOG(INFO) << "size: " << samples_.size();
   // Finds all ground truth files under ground_truth_dir.
   std::unordered_set<std::string> gt_exts{".raw"};
   ret = tflite::evaluation::GetSortedFileNames(
@@ -80,7 +79,6 @@ ADE20K::ADE20K(const DataFormat& input_format, const DataFormat& output_format,
     LOG(FATAL) << "Failed to list all the ground truth files in provided path";
     return;
   }
-  LOG(INFO) << "gt size: " << ground_truth_list_.size();
 
   // Prepares the preprocessing stage.
   tflite::evaluation::ImagePreprocessingConfigBuilder builder(

--- a/cpp/datasets/ade20k.cc
+++ b/cpp/datasets/ade20k.cc
@@ -1,0 +1,224 @@
+/* Copyright 2020 The MLPerf Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#include "cpp/datasets/ade20k.h"
+
+#include <cstdint>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <numeric>
+#include <sstream>
+#include <streambuf>
+#include <string>
+#include <unordered_set>
+
+#include "cpp/utils.h"
+#include "tensorflow/lite/kernels/kernel_util.h"
+#include "tensorflow/lite/tools/evaluation/proto/evaluation_stages.pb.h"
+#include "tensorflow/lite/tools/evaluation/stages/image_preprocessing_stage.h"
+#include "tensorflow/lite/tools/evaluation/utils.h"
+
+namespace mlperf {
+namespace mobile {
+namespace {
+inline TfLiteType DataType2TfType(DataType::Type type) {
+  switch (type) {
+    case DataType::Float32:
+      return kTfLiteFloat32;
+    case DataType::Uint8:
+      return kTfLiteUInt8;
+    case DataType::Int8:
+      return kTfLiteInt8;
+    case DataType::Float16:
+      return kTfLiteFloat16;
+  }
+  return kTfLiteNoType;
+}
+}  // namespace
+
+ADE20K::ADE20K(const DataFormat& input_format, const DataFormat& output_format,
+               const std::string& image_dir,
+               const std::string& ground_truth_dir, int num_classes,
+               int image_width, int image_height)
+    : Dataset(input_format, output_format),
+      num_classes_(num_classes),
+      image_width_(image_width),
+      image_height_(image_height) {
+  if (input_format_.size() != 1 || output_format_.size() != 1) {
+    LOG(FATAL) << "Imagenet only supports 1 input and 1 output";
+    return;
+  }
+  // Finds all images under image_dir.
+  std::unordered_set<std::string> exts{".rgb8", ".jpg", ".jpeg"};
+  TfLiteStatus ret = tflite::evaluation::GetSortedFileNames(
+      tflite::evaluation::StripTrailingSlashes(image_dir), &image_list_, exts);
+  if (ret == kTfLiteError || image_list_.empty()) {
+    LOG(FATAL) << "Failed to list all the images file in provided path";
+    return;
+  }
+  samples_ =
+      std::vector<std::vector<std::vector<uint8_t>*>>(image_list_.size());
+  LOG(INFO) << "size: " << samples_.size();
+  // Finds all ground truth files under ground_truth_dir.
+  std::unordered_set<std::string> gt_exts{".raw"};
+  ret = tflite::evaluation::GetSortedFileNames(
+      tflite::evaluation::StripTrailingSlashes(ground_truth_dir),
+      &ground_truth_list_, gt_exts);
+  if (ret == kTfLiteError || ground_truth_list_.empty()) {
+    LOG(FATAL) << "Failed to list all the ground truth files in provided path";
+    return;
+  }
+  LOG(INFO) << "gt size: " << ground_truth_list_.size();
+
+  // Prepares the preprocessing stage.
+  tflite::evaluation::ImagePreprocessingConfigBuilder builder(
+      "image_preprocessing", DataType2TfType(input_format_.at(0).type));
+  builder.AddDefaultNormalizationStep();
+  preprocessing_stage_.reset(
+      new tflite::evaluation::ImagePreprocessingStage(builder.build()));
+  if (preprocessing_stage_->Init() != kTfLiteOk) {
+    LOG(FATAL) << "Failed to init preprocessing stage";
+  }
+}
+
+void ADE20K::LoadSamplesToRam(const std::vector<QuerySampleIndex>& samples) {
+  for (QuerySampleIndex sample_idx : samples) {
+    // Preprocessing.
+    if (sample_idx >= image_list_.size()) {
+      LOG(FATAL) << "Sample index out of bound";
+    }
+    std::string filename = image_list_.at(sample_idx);
+    preprocessing_stage_->SetImagePath(&filename);
+    if (preprocessing_stage_->Run() != kTfLiteOk) {
+      LOG(FATAL) << "Failed to run preprocessing stage";
+    }
+
+    // Move data out of preprocessing_stage_ so it can be reused.
+    int total_byte = input_format_[0].size * input_format_[0].GetByte();
+    void* data_void = preprocessing_stage_->GetPreprocessedImageData();
+    std::vector<uint8_t>* data_uint8 = new std::vector<uint8_t>(total_byte);
+    std::copy(static_cast<uint8_t*>(data_void),
+              static_cast<uint8_t*>(data_void) + total_byte,
+              data_uint8->begin());
+    samples_.at(sample_idx).push_back(data_uint8);
+  }
+}
+
+void ADE20K::UnloadSamplesFromRam(
+    const std::vector<QuerySampleIndex>& samples) {
+  for (QuerySampleIndex sample_idx : samples) {
+    for (std::vector<uint8_t>* v : samples_.at(sample_idx)) {
+      delete v;
+    }
+    samples_.at(sample_idx).clear();
+  }
+}
+
+std::vector<uint8_t> ADE20K::ProcessOutput(const int sample_idx,
+                                           const std::vector<void*>& outputs) {
+  std::vector<uint64_t> tps, fps, fns;
+  std::string filename = ground_truth_list_.at(sample_idx);
+  std::ifstream stream(filename, std::ios::in | std::ios::binary);
+  std::vector<uint8_t> ground_truth_vector(
+      (std::istreambuf_iterator<char>(stream)),
+      std::istreambuf_iterator<char>());
+
+  auto output = reinterpret_cast<int32_t*>(outputs[0]);
+
+  for (int c = 1; c <= num_classes_; c++) {
+    uint64_t true_positive = 0, false_positive = 0, false_negative = 0;
+
+    for (int i = 0; i < (image_width_ * image_height_ - 1); i++) {
+      auto p = (uint8_t)0x000000ff & output[i];
+      auto g = ground_truth_vector[i];
+
+      // trichotomy
+      if ((p == c) or (g == c)) {
+        if (p == g) {
+          true_positive++;
+        } else if (p == c) {
+          if ((g > 0) && (g <= num_classes_)) false_positive++;
+        } else {
+          false_negative++;
+        }
+      }
+    }
+
+    tps.push_back(true_positive);
+    fps.push_back(false_positive);
+    fns.push_back(false_negative);
+  }
+
+  if (!initialized_) {
+    initialized_ = true;
+
+    for (int j = 0; j < num_classes_; j++) {
+      tp_acc_.push_back(tps[j]);
+      fp_acc_.push_back(fps[j]);
+      fn_acc_.push_back(fns[j]);
+    }
+  } else {
+    for (int j = 0; j < num_classes_; j++) {
+      tp_acc_[j] += tps[j];
+      fp_acc_[j] += fps[j];
+      fn_acc_[j] += fns[j];
+    }
+  }
+
+#if __DEBUG__
+  for (int j = 0; j < num_classes_; j++) {
+    LOG(INFO) << tp_acc_[j] << ", " << fp_acc_[j] << ", " << fn_acc_[j];
+    if (j < 30) std::cout << ", ";
+  }
+  LOG(INFO) << "\n";
+  for (int j = 0; j < num_classes_; j++) {
+    LOG(INFO) << "mIOU class " << j + 1 << ": "
+              << tp_acc_[j] * 1.0 / (tp_acc_[j] + fp_acc_[j] + fn_acc_[j])
+              << "\n";
+  }
+#endif
+
+  return std::vector<uint8_t>();
+}
+
+float ADE20K::ComputeAccuracy() {
+  float iou_sum = 0.0;
+  for (int j = 0; j < num_classes_; j++) {
+    auto iou = tp_acc_[j] * 1.0 / (tp_acc_[j] + fp_acc_[j] + fn_acc_[j]);
+#if __DEBUG__
+    LOG(INFO) << "IOU class " << j + 1 << ": " << tp_acc_[j] << ", "
+              << fp_acc_[j] << ", " << fn_acc_[j] << ", " << iou << "\n";
+#endif
+    iou_sum += iou;
+  }
+#if __DEBUG__
+  LOG(INFO) << "mIOU over_all: " << iou_sum / num_classes_ << "\n";
+#endif
+  return iou_sum / num_classes_;
+}
+
+std::string ADE20K::ComputeAccuracyString() {
+  float result = ComputeAccuracy();
+  if (result == 0.0f) {
+    return std::string("N/A");
+  }
+  std::stringstream stream;
+  stream << std::fixed << std::setprecision(4) << result << " mIoU";
+
+  return stream.str();
+}
+
+}  // namespace mobile
+}  // namespace mlperf

--- a/cpp/datasets/ade20k.h
+++ b/cpp/datasets/ade20k.h
@@ -1,0 +1,96 @@
+/* Copyright 2012 The MLPerf Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#ifndef MLPERF_DATASETS_ADE20K_H_
+#define MLPERF_DATASETS_ADE20K_H_
+
+#include <cstdint>
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+#include "cpp/dataset.h"
+#include "tensorflow/lite/tools/evaluation/stages/image_preprocessing_stage.h"
+
+namespace mlperf {
+namespace mobile {
+
+// Implements the ADE20K dataset for image segmentation.
+class ADE20K : public Dataset {
+ public:
+  // ADE20K assumes that there is a single input resevered for the image data
+  // and single output which contains the probabilities of every classes. The
+  // order of images under image_dir should be the same as the original
+  // ADE20K dataset.
+  ADE20K(const DataFormat& input_format, const DataFormat& output_format,
+         const std::string& image_dir, const std::string& ground_truth_dir,
+         int num_classes, int image_width, int image_height);
+
+  // Returns the name of the dataset.
+  const std::string& Name() const override { return name_; }
+
+  // Total number of samples in library.
+  size_t TotalSampleCount() override { return samples_.size(); }
+
+  void LoadSamplesToRam(const std::vector<QuerySampleIndex>& samples) override;
+  void UnloadSamplesFromRam(
+      const std::vector<QuerySampleIndex>& samples) override;
+
+  // GetData returns the data of a specific input.
+  std::vector<void*> GetData(int sample_idx) override {
+    std::vector<void*> data;
+    for (std::vector<uint8_t>* v : samples_.at(sample_idx)) {
+      data.push_back(v->data());
+    }
+    return data;
+  }
+
+  // ProcessOutput processes the output data before sending to mlperf.
+  std::vector<uint8_t> ProcessOutput(
+      const int sample_idx, const std::vector<void*>& outputs) override;
+
+  // ComputeAccuracy Calculate the accuracy if the processed outputs.
+  float ComputeAccuracy() override;
+
+  // ComputeAccuracyString returns a string representing the accuracy.
+  std::string ComputeAccuracyString() override;
+
+ private:
+  const std::string name_ = "ADE20K";
+  // List of the fullpath of images.
+  std::vector<std::string> image_list_;
+  // List of the fullpath of groun dtruth file.
+  std::vector<std::string> ground_truth_list_;
+  // Loaded samples in RAM.
+  std::vector<std::vector<std::vector<uint8_t>*>> samples_;
+
+  // preprocessing_stage_ conducts preprocessing of images.
+  std::unique_ptr<tflite::evaluation::ImagePreprocessingStage>
+      preprocessing_stage_;
+
+  // number of classes
+  int num_classes_;
+
+  // image w, h
+  int image_width_, image_height_;
+
+  // accumulators for true positive, false positive, and false negative
+  std::vector<uint64_t> tp_acc_, fp_acc_, fn_acc_;
+
+  bool initialized_ = false;
+};
+
+}  // namespace mobile
+}  // namespace mlperf
+#endif  // MLPERF_DATASETS_ADE20K_H_

--- a/cpp/datasets/ade20k.h
+++ b/cpp/datasets/ade20k.h
@@ -1,4 +1,4 @@
-/* Copyright 2012 The MLPerf Authors. All Rights Reserved.
+/* Copyright 2020 The MLPerf Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -43,7 +43,10 @@ class ADE20K : public Dataset {
   // Total number of samples in library.
   size_t TotalSampleCount() override { return samples_.size(); }
 
+  // Loads the requested query samples into memory.
   void LoadSamplesToRam(const std::vector<QuerySampleIndex>& samples) override;
+
+  // Unloads the requested query samples from memory.
   void UnloadSamplesFromRam(
       const std::vector<QuerySampleIndex>& samples) override;
 
@@ -79,13 +82,13 @@ class ADE20K : public Dataset {
   std::unique_ptr<tflite::evaluation::ImagePreprocessingStage>
       preprocessing_stage_;
 
-  // number of classes
+  // Number of classes in the output of the model.
   int num_classes_;
 
-  // image w, h
+  // The width and height of the input images.
   int image_width_, image_height_;
 
-  // accumulators for true positive, false positive, and false negative
+  // Accumulators for true positive, false positive, and false negative.
   std::vector<uint64_t> tp_acc_, fp_acc_, fn_acc_;
 
   bool initialized_ = false;

--- a/java/org/mlperf/inference/MLPerfDriverWrapper.java
+++ b/java/org/mlperf/inference/MLPerfDriverWrapper.java
@@ -113,7 +113,6 @@ public final class MLPerfDriverWrapper implements AutoCloseable {
       int imageWidth,
       int imageHeight);
 
-
   // Return a pointer of a new DummyDataset C++ object.
   private static native long dummyDataset(long backendHandle, int datasetType);
 
@@ -184,15 +183,9 @@ public final class MLPerfDriverWrapper implements AutoCloseable {
     }
 
     public Builder useAde20k(
-        String imageDir,
-        String groundtruthDir,
-        int numClasses,
-        int imageWidth,
-        int imageHeight) {
+        String imageDir, String groundtruthDir, int numClasses, int imageWidth, int imageHeight) {
       nativeDeleteDataset(dataset);
-      dataset =
-          ade20k(
-              getBackend(), imageDir, groundtruthDir, numClasses, imageWidth, imageHeight);
+      dataset = ade20k(getBackend(), imageDir, groundtruthDir, numClasses, imageWidth, imageHeight);
       return this;
     }
 

--- a/java/org/mlperf/inference/MLPerfDriverWrapper.java
+++ b/java/org/mlperf/inference/MLPerfDriverWrapper.java
@@ -104,6 +104,16 @@ public final class MLPerfDriverWrapper implements AutoCloseable {
   // Return a pointer of a new Squad C++ object.
   private static native long squad(long backendHandle, String inputFile, String groundtruthFile);
 
+  // Return a pointer of a new ADE20K C++ object.
+  private static native long ade20k(
+      long backendHandle,
+      String imageDir,
+      String groundtruthDir,
+      int numClasses,
+      int imageWidth,
+      int imageHeight);
+
+
   // Return a pointer of a new DummyDataset C++ object.
   private static native long dummyDataset(long backendHandle, int datasetType);
 
@@ -170,6 +180,19 @@ public final class MLPerfDriverWrapper implements AutoCloseable {
     public Builder useSquad(String inputFile, String groundtruthFile) {
       nativeDeleteDataset(dataset);
       dataset = squad(getBackend(), inputFile, groundtruthFile);
+      return this;
+    }
+
+    public Builder useAde20k(
+        String imageDir,
+        String groundtruthDir,
+        int numClasses,
+        int imageWidth,
+        int imageHeight) {
+      nativeDeleteDataset(dataset);
+      dataset =
+          ade20k(
+              getBackend(), imageDir, groundtruthDir, numClasses, imageWidth, imageHeight);
       return this;
     }
 

--- a/java/org/mlperf/inference/MLPerfEvaluation.java
+++ b/java/org/mlperf/inference/MLPerfEvaluation.java
@@ -508,7 +508,8 @@ public class MLPerfEvaluation extends AppCompatActivity implements Handler.Callb
             success = false;
           }
         }
-        if (!new File(MLPerfTasks.getLocalPath(dataset.getGroundtruthSrc())).canRead()) {
+        if (dataset.getGroundtruthSrc().startsWith(ASSETS_PREFIX)
+            && (!new File(MLPerfTasks.getLocalPath(dataset.getGroundtruthSrc())).canRead())) {
           if (!extractFile(dataset.getGroundtruthSrc())) {
             success = false;
           }

--- a/java/org/mlperf/inference/RunMLPerfWorker.java
+++ b/java/org/mlperf/inference/RunMLPerfWorker.java
@@ -118,8 +118,8 @@ public final class RunMLPerfWorker implements Handler.Callback {
                 MLPerfTasks.getLocalPath(dataset.getGroundtruthSrc()));
           case ADE20K:
             builder.useAde20k(
-                dataset.getPath() + "images",
-                dataset.getPath() + "annotations",
+                dataset.getPath(),
+                dataset.getGroundtruthSrc(),
                 /*numClasses=*/ 31,
                 /*imageWidth=*/ 512,
                 /*imageHeight=*/ 512);

--- a/java/org/mlperf/inference/RunMLPerfWorker.java
+++ b/java/org/mlperf/inference/RunMLPerfWorker.java
@@ -115,6 +115,13 @@ public final class RunMLPerfWorker implements Handler.Callback {
             builder.useSquad(
                 MLPerfTasks.getLocalPath(dataset.getPath()),
                 MLPerfTasks.getLocalPath(dataset.getGroundtruthSrc()));
+          case ADE20K:
+            builder.useAde20k(
+                dataset.getPath() + "images",
+                dataset.getPath() + "annotations",
+                /*numClasses=*/ 31,
+                /*imageWidth=*/ 512,
+                /*imageHeight=*/ 512);
             break;
         }
       }

--- a/java/org/mlperf/inference/assets/tasks.pbtxt
+++ b/java/org/mlperf/inference/assets/tasks.pbtxt
@@ -97,7 +97,8 @@ task {
   dataset {
     name: "ADE20k"
     type: ADE20K
-    path: "/sdcard/mlperf_datasets/ade20k/"
+    path: "/sdcard/mlperf_datasets/ade20k/images"
+    groundtruth_src: "/sdcard/mlperf_datasets/ade20k/annotations"
   }
   model {
     name: "Deeplab-v3 Mobilenet-v2 F32"

--- a/java/org/mlperf/inference/assets/tasks.pbtxt
+++ b/java/org/mlperf/inference/assets/tasks.pbtxt
@@ -110,6 +110,11 @@ task {
     src: "https://github.com/mlperf/mobile_app/raw/model_repo_v0.7/tflite/deeplabv3_mnv2_ade20k_uint8.tflite"
     tags: "uint8"
   }
+  model {
+    name: "Deeplab-v3 Mobilenet-v2 INT8"
+    src: "https://github.com/mlperf/mobile_app/raw/model_repo_v0.7/tflite/deeplabv3_mnv2_ade20k_int8.tflite"
+    tags: "int8"
+  }
   min_query_count: 100
   min_duration_ms: 1000
 }

--- a/java/org/mlperf/inference/assets/tasks.pbtxt
+++ b/java/org/mlperf/inference/assets/tasks.pbtxt
@@ -85,11 +85,15 @@ task {
     type: ADE20K
     path: "/sdcard/mlperf_datasets/ade20k/"
   }
-
   model {
     name: "Deeplab-v3 Mobilenet-v2 F32"
-    src: "https://github.com/mlperf/mobile_app/raw/model_repo_v0.7/tflite/deeplabv3_mnv2_ade20k_float.tflite"
+    src: "https://github.com/freedomtan/mobile_app/raw/model_repo_v0.7_deeplabv3/tflite/deeplabv3_mnv2_ade20k_float.tflite"
     tags: "float32"
+  }
+  model {
+    name: "Deeplab-v3 Mobilenet-v2 UINT8"
+    src: "https://github.com/freedomtan/mobile_app/raw/model_repo_v0.7_deeplabv3/tflite/deeplabv3_mnv2_ade20k_uint8.tflite"
+    tags: "uint8"
   }
   min_query_count: 100
   min_duration_ms: 1000

--- a/java/org/mlperf/inference/assets/tasks.pbtxt
+++ b/java/org/mlperf/inference/assets/tasks.pbtxt
@@ -87,12 +87,12 @@ task {
   }
   model {
     name: "Deeplab-v3 Mobilenet-v2 F32"
-    src: "https://github.com/freedomtan/mobile_app/raw/model_repo_v0.7_deeplabv3/tflite/deeplabv3_mnv2_ade20k_float.tflite"
+    src: "https://github.com/mlperf/mobile_app/raw/model_repo_v0.7/tflite/deeplabv3_mnv2_ade20k_float.tflite"
     tags: "float32"
   }
   model {
     name: "Deeplab-v3 Mobilenet-v2 UINT8"
-    src: "https://github.com/freedomtan/mobile_app/raw/model_repo_v0.7_deeplabv3/tflite/deeplabv3_mnv2_ade20k_uint8.tflite"
+    src: "https://github.com/mlperf/mobile_app/raw/model_repo_v0.7/tflite/deeplabv3_mnv2_ade20k_uint8.tflite"
     tags: "uint8"
   }
   min_query_count: 100

--- a/java/org/mlperf/inference/jni/BUILD
+++ b/java/org/mlperf/inference/jni/BUILD
@@ -37,6 +37,7 @@ cc_library(
         "//cpp:mlperf_driver",
         "//cpp/backends:dummy_backend",
         "//cpp/backends:tflite",
+        "//cpp/datasets:ade20k",
         "//cpp/datasets:coco",
         "//cpp/datasets:dummy_dataset",
         "//cpp/datasets:imagenet",

--- a/java/org/mlperf/inference/jni/dataset_jni.cc
+++ b/java/org/mlperf/inference/jni/dataset_jni.cc
@@ -18,6 +18,7 @@ limitations under the License.
 #include <string>
 
 #include "cpp/backend.h"
+#include "cpp/datasets/ade20k.h"
 #include "cpp/datasets/coco.h"
 #include "cpp/datasets/dummy_dataset.h"
 #include "cpp/datasets/imagenet.h"
@@ -88,6 +89,21 @@ JNIEXPORT jlong JNICALL Java_org_mlperf_inference_MLPerfDriverWrapper_squad(
   return reinterpret_cast<jlong>(squad_ptr.release());
 }
 
+JNIEXPORT jlong JNICALL Java_org_mlperf_inference_MLPerfDriverWrapper_ade20k(
+    JNIEnv* env, jclass clazz, jlong backend_handle, jstring jimage_dir,
+    jstring groundtruth_dir, jint num_classes, jint image_width,
+    jint image_height) {
+  // Convert parameters to C++.
+  Backend* backend = convertLongToBackend(env, backend_handle);
+  std::string image_dir = env->GetStringUTFChars(jimage_dir, nullptr);
+  std::string gt_dir = env->GetStringUTFChars(groundtruth_dir, nullptr);
+
+  // Create a new Coco object.
+  std::unique_ptr<mlperf::mobile::ADE20K> ade20k_ptr(new mlperf::mobile::ADE20K(
+      backend->GetInputFormat(), backend->GetOutputFormat(), image_dir, gt_dir,
+      num_classes, image_width, image_height));
+  return reinterpret_cast<jlong>(ade20k_ptr.release());
+}
 JNIEXPORT jlong JNICALL
 Java_org_mlperf_inference_MLPerfDriverWrapper_dummyDataset(JNIEnv* env,
                                                            jclass clazz,

--- a/java/org/mlperf/inference/jni/dataset_jni.cc
+++ b/java/org/mlperf/inference/jni/dataset_jni.cc
@@ -98,7 +98,7 @@ JNIEXPORT jlong JNICALL Java_org_mlperf_inference_MLPerfDriverWrapper_ade20k(
   std::string image_dir = env->GetStringUTFChars(jimage_dir, nullptr);
   std::string gt_dir = env->GetStringUTFChars(groundtruth_dir, nullptr);
 
-  // Create a new Coco object.
+  // Create a new Ade20k object.
   std::unique_ptr<mlperf::mobile::ADE20K> ade20k_ptr(new mlperf::mobile::ADE20K(
       backend->GetInputFormat(), backend->GetOutputFormat(), image_dir, gt_dir,
       num_classes, image_width, image_height));


### PR DESCRIPTION
ADE20K implementation. Tested with 
```
./bazel-bin/cpp/binary/main tflite  ade20k \
  --mode=PerformanceOnly \
  --output_dir=/tmp/test_output \ 
  --model_file=/tmp/freeze_quant_ops16_32c_clean.tflite  \
  --images_directory=/tmp/ade20k_512/images/validation \
  --ground_truth_directory=/tmp/ade20k_512/annotations/raw \
  --num_threads=4 
```
and
```
./bazel-bin/cpp/binary/main tflite  ade20k \
  --mode=PerformanceOnly \
  --output_dir=/tmp/test_output \ 
  --model_file=/tmp/freeze_float_ops16_32c_clean.tflite  \
  --images_directory=/tmp/ade20k_512/images/validation \
  --ground_truth_directory=/tmp/ade20k_512/annotations/raw \
  --num_threads=4 
```